### PR TITLE
Corrigindo falha display none de projetos

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -471,9 +471,7 @@ footer p {
       box-shadow: 0 1px 4px white;
       border-radius: 12px;
     }
-    .projeto:hover {
-      display:none;
-    }
+
 
     /* menu hamburguer funcional */
     .menuBurgao {


### PR DESCRIPTION
Removido display: none do :hover na aba "Projetos" para corrigir bug de exibição e melhorar a compatibilidade com dispositivos móveis.
